### PR TITLE
Use cache busting on APT update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
 FROM ubuntu:22.04
 
-MAINTAINER rdemko2332@gmail.com
+LABEL maintainer="rdemko2332@gmail.com"
 
-RUN apt-get -qq update --fix-missing
 
 #Installing Software
-RUN apt-get install -y \
-  wget \
-  bowtie2=2.4.4-1 \
-  samtools=1.13-4 \
-  bzip2 \
-  sra-toolkit \
-  python3-pip \
-  cpanminus
+RUN apt-get update && \
+    apt-get install -y \
+    wget \
+    bowtie2=2.4.4-1 \
+    samtools=1.13-4 \
+    bzip2 \
+    sra-toolkit \
+    python3-pip \
+    cpanminus \
+  && rm -rf /var/lib/apt/lists/*
   
 RUN pip install marker_alignments && cpanm List::MoreUtils
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:22.04
+
+MAINTAINER rdemko2332@gmail.com
+
+RUN apt-get -qq update --fix-missing
+
+#Installing Software
+RUN apt-get install -y \
+  wget \
+  bowtie2=2.4.4-1 \
+  samtools=1.13-4 \
+  bzip2 \
+  sra-toolkit \
+  python3-pip \
+  cpanminus
+  
+RUN pip install marker_alignments && cpanm List::MoreUtils

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,9 @@ RUN apt-get install -y \
   cpanminus
   
 RUN pip install marker_alignments && cpanm List::MoreUtils
+
+COPY /bin/* /usr/bin/
+
+RUN cd /usr/bin/ && chmod +x *
+
+WORKDIR /work

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+@Library('pipelib')
+import org.veupathdb.lib.Builder
+
+node('centos8') {
+  def builder = new Builder(this)
+
+  checkout scm
+  builder.buildContainers([
+    [ name: 'corral' ]
+  ])
+}

--- a/README.md
+++ b/README.md
@@ -1,21 +1,9 @@
 # Marker alignments in Nextflow
 
-## Installation
-This workflow is not containerised, but the dependencies are quite minimal:
-- `bowtie2`
-- [Marker alignments package](https://github.com/wbazant/marker_alignments) and its tool `marker_alignments`.
-
-Additionally, `samtools stats` is the default and recommended for alignment stats.
-
-By default, `bowtie2`, `marker_alignments` and `samtools` are assumed to be on `$PATH` but you can provide a path to an executable in the pipeline config.
-
-
-If you want to use `--downloadMethod wget` you also need `wget`. If you want to use `--downloadMethod sra` you need the SRA EUtils, with `prefetch` and `fastq-dump` on `$PATH`.
-
-`--unpackMethod bz2` requires `bzip2` on `$PATH`.
-
-You also need a `bowtie2` reference database of taxonomic markers, like ChocoPhlAn or EukDetect.
-
+### Get Started
+  * Install Nextflow
+    
+    `curl https://get.nextflow.io | bash`
 
 ## Usage
 
@@ -31,6 +19,7 @@ Main parameters:
 | bowtie2Command | shell | Run bowtie2 |
 | alignmentStatsCommand | shell | `samtools stats` or other |
 | summarizeAlignmentsCommand | shell | path to `marker_alignments` optionally with filter arguments to use|
+| apiKey | string | ncbi ApiKey |
 
 Optional parameters:
 
@@ -40,47 +29,5 @@ Optional parameters:
 | unpackMethod | "bz2" | for FTP .tar.bz2 content |
 
 ### Example 
-I run it like that:
 
-#### `run.sh`
-```
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-REF_PATH="~/eukprot"
-
-nextflow pull wbazant/marker-alignments-nextflow -r main
-
-nextflow run wbazant/marker-alignments-nextflow -r main \
-  --inputPath $DIR/in.tsv  \
-  --resultDir $DIR/results \
-  --downloadMethod wget \
-  --unpackMethod bz2 \
-  --libraryLayout paired \
-  --refdb ${REF_PATH}/ncbi_eukprot_met_arch_markers.fna \
-  --marker_to_taxon_path ${REF_PATH}/busco_taxid_link.txt  \
-  -c $DIR/cluster.conf \
-  -with-trace -resume | tee $DIR/tee.out
-
-```
-
-#### `cluster.conf`
-
-```  
-process {
-  executor = 'lsf'
-  maxForks = 60
-  
-  withLabel: 'download' {
-    maxForks = 5
-    maxRetries = 3
-  }
-  withLabel: 'align' {
-    errorStrategy = 'finish'
-  }
-}
-```
-
-#### `in.tsv`
-```
-SRS011061       https://downloads.hmpdacc.org/dacc/hhs/genome/microbiome/wgs/analysis/hmwgsqc/v1/SRS011061.tar.bz2
-SRS011086       https://downloads.hmpdacc.org/dacc/hhs/genome/microbiome/wgs/analysis/hmwgsqc/v1/SRS011086.tar.bz2
-```
+ `nextflow run VEuPathDB/blastSimilarity -with-trace -c  <config_file> -r main`

--- a/data/test.tsv
+++ b/data/test.tsv
@@ -1,0 +1,2 @@
+run_accession
+SRR13004501

--- a/main.nf
+++ b/main.nf
@@ -241,8 +241,10 @@ workflow {
     xs = singleWget(input)
   } else if(params.downloadMethod == 'wget' && params.libraryLayout == 'paired'){
     if(params.unpackMethod == 'bz2'){
+      input = Channel.fromPath(params.inputPath).splitCsv(sep: "\t")
       xs = pairedWgetUnpackBz2(input)
     } else {
+      input = Channel.fromPath(params.inputPath).splitCsv(sep: "\t")
       xs = pairedWget(input)
     }
   } else if(params.downloadMethod == 'sra' && params.libraryLayout == 'single'){

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,10 +1,21 @@
 params {
-  wgetCommand = "wget"
+  inputPath = "data/test.tsv"
+  apiKey = ""
+  refdb = "$launchDir/data/database/refdb"
   unpackMethod = ""
-  markerToTaxonPath = ""
-  bowtie2Command = "bowtie2 --omit-sec-seq --no-discordant --no-unal -k10"
   alignmentStatsCommand = "samtools stats"
-  summarizeAlignmentsCommand = "marker_alignments --min-read-query-length 60 --min-taxon-num-markers 2 --min-taxon-num-reads 2 --min-taxon-better-marker-cluster-averages-ratio 1.01 --threshold-avg-match-identity-to-call-known-taxon 0.97  --threshold-num-taxa-to-call-unknown-taxon 1 --threshold-num-markers-to-call-unknown-taxon 4     --threshold-num-reads-to-call-unknown-taxon 8"
+  resultDir = "$launchDir/output"
+  libraryLayout = "paired"
+  downloadMethod = "sra"
+  markerToTaxonPath = "$launchDir/data/marker-to-taxon-id.tsv"
+  bowtie2Command = "bowtie2 --omit-sec-seq --no-discordant --no-unal -a"
+  summarizeAlignmentsCommand = 'marker_alignments --min-read-query-length 60 --min-taxon-num-markers 2 --min-taxon-num-reads 2 --min-taxon-better-marker-cluster-averages-ratio 1.01 --threshold-avg-match-identity-to-call-known-taxon 0.97  --threshold-num-taxa-to-call-unknown-taxon 1 --threshold-num-markers-to-call-unknown-taxon 4     --threshold-num-reads-to-call-unknown-taxon 8'
   summaryFormat = "matrix"
   summaryColumn = "cpm"
+}
+process {
+  container = "veupathdb/corral:latest"
+}
+docker {
+    enabled = true
 }


### PR DESCRIPTION
The apt-get update should be in the same layer as the installation to prevent Docker cache issues. I also purge the APT cache within the same layer to reduce image/layer size, and I’ve replaced the deprecated MAINTAINER directive with a LABEL